### PR TITLE
Fixed a typo and corrected/updated the top 500 ranking

### DIFF
--- a/hpc_machines/betzy.md
+++ b/hpc_machines/betzy.md
@@ -1,6 +1,6 @@
 # Betzy
 
-Named after [Mary Ann Elizabeth (Betzy) Stephansen](https://en.wikipedia.org/wiki/Elizabeth_Stephansen), the first Norwegian women to be awarded a doctorate degree.
+Named after [Mary Ann Elizabeth (Betzy) Stephansen](https://en.wikipedia.org/wiki/Elizabeth_Stephansen), the first Norwegian woman to be awarded a doctorate degree.
 
 
 ### The most powerful supercomputer in Norway
@@ -21,7 +21,7 @@ Betzy is a BullSequana XH2000, provided by Atos, and will  give Norwegian resear
 | Operating System   | Red Hat Enterprise Linux 7 |
 | Total disc capacity     |	2.5 PB  |
 | Interconnect  |	InfiniBand HDR 100, Dragonfly+ topology |
-| Top500 June 2020 | 56th place \@ 1250 nodes, 76% efficiency|
+| Top500 June 2020 | 55th place \@ 1250 nodes, 76% efficiency|
 
 Almost all components are liquid cooled resulting in a very high cooling efficiency, 95% of heat being captured to water.
 


### PR DESCRIPTION
I was just using this page as a reference for a document, and spotted a typo and noticed that the mentioned Top 500 ranking does not match the referenced version of the ranking at [www.top500.org](https://www.top500.org/lists/top500/list/2020/06/?page=1).